### PR TITLE
feat: add `prefix` and `suffix` props to `NumberTicker` component

### DIFF
--- a/src/lib/components/magic/number-ticker/number-ticker.svelte
+++ b/src/lib/components/magic/number-ticker/number-ticker.svelte
@@ -10,6 +10,8 @@
 		delay?: number;
 		decimalPlaces?: number;
 		class?: string;
+		prefix?: string;
+		suffix?: string;
 	}
 
 	let {
@@ -19,6 +21,8 @@
 		delay = 0,
 		decimalPlaces = 0,
 		class: className,
+		prefix = "",
+		suffix = "",
 	}: NumberTickerProps = $props();
 
 	let spanRef: HTMLSpanElement | null = $state(null);
@@ -50,10 +54,10 @@
 
 			// Update display
 			if (spanRef) {
-				spanRef.textContent = Intl.NumberFormat("en-US", {
+				spanRef.textContent = `${prefix}${Intl.NumberFormat("en-US", {
 					minimumFractionDigits: decimalPlaces,
 					maximumFractionDigits: decimalPlaces,
-				}).format(Number(position.toFixed(decimalPlaces)));
+				}).format(Number(position.toFixed(decimalPlaces)))}${suffix}`;
 			}
 
 			// Continue animation if not settled
@@ -62,10 +66,10 @@
 				requestAnimationFrame(step);
 			} else if (spanRef) {
 				// Ensure final value is exact
-				spanRef.textContent = Intl.NumberFormat("en-US", {
+				spanRef.textContent = `${prefix}${Intl.NumberFormat("en-US", {
 					minimumFractionDigits: decimalPlaces,
 					maximumFractionDigits: decimalPlaces,
-				}).format(Number(target.toFixed(decimalPlaces)));
+				}).format(Number(target.toFixed(decimalPlaces)))}${suffix}`;
 			}
 		}
 
@@ -97,8 +101,10 @@
 	bind:this={spanRef}
 	class={cn("inline-block tracking-wider text-black tabular-nums dark:text-white", className)}
 >
+	{prefix}
 	{Intl.NumberFormat("en-US", {
 		minimumFractionDigits: decimalPlaces,
 		maximumFractionDigits: decimalPlaces,
 	}).format(Number((direction === "down" ? value : startValue).toFixed(decimalPlaces)))}
+	{suffix}
 </span>

--- a/src/routes/magic/docs/components/number-ticker/data.ts
+++ b/src/routes/magic/docs/components/number-ticker/data.ts
@@ -136,6 +136,18 @@ export const data: ComponentDoc = {
 					default: '""',
 					description: "Additional CSS classes to apply.",
 				},
+				{
+					name: "prefix",
+					type: "string",
+					default: '""',
+					description: "Prefix to display before the number.",
+				},
+				{
+					name: "suffix",
+					type: "string",
+					default: '""',
+					description: "Suffix to display after the number.",
+				},
 			],
 		},
 	],

--- a/src/routes/magic/docs/components/number-ticker/data.ts
+++ b/src/routes/magic/docs/components/number-ticker/data.ts
@@ -10,6 +10,8 @@ import NumberPickerStartValue from "./examples/number-picker-start-value.svelte"
 import NumberPickerStartValueCode from "./examples/number-picker-start-value.svelte?raw";
 import NumberTickerDecimal from "./examples/number-ticker-decimal.svelte";
 import NumberTickerDecimalCode from "./examples/number-ticker-decimal.svelte?raw";
+import NumberPickerPrefixSuffix from "./examples/number-ticker-prefix-suffix.svelte";
+import NumberPickerPrefixSuffixCode from "./examples/number-ticker-prefix-suffix.svelte?raw";
 
 /** Component metadata for navigation */
 export const meta: ComponentMeta = {
@@ -36,6 +38,15 @@ const examples: Example[] = [
 		code: {
 			filename: "number-ticker.svelte",
 			filecode: NumberPickerStartValueCode,
+			lang: "svelte",
+		},
+	},
+	{
+		name: "With Prefix and Suffix",
+		preview: NumberPickerPrefixSuffix,
+		code: {
+			filename: "number-ticker.svelte",
+			filecode: NumberPickerPrefixSuffixCode,
 			lang: "svelte",
 		},
 	},

--- a/src/routes/magic/docs/components/number-ticker/docs.md
+++ b/src/routes/magic/docs/components/number-ticker/docs.md
@@ -102,6 +102,18 @@ Copy and paste the component source code into your project.
 />
 ```
 
+### With Prefix and Suffix
+
+```svelte
+<NumberTicker
+  value={75}
+  startValue={0}
+  prefix="$"
+  suffix="USD"
+  class="text-4xl font-bold"
+/>
+```
+
 ## Notes
 
 - Uses spring physics (damping: 60, stiffness: 100) for smooth animation

--- a/src/routes/magic/docs/components/number-ticker/examples/number-ticker-prefix-suffix.svelte
+++ b/src/routes/magic/docs/components/number-ticker/examples/number-ticker-prefix-suffix.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+	import { NumberTicker } from "$lib/components/magic/number-ticker";
+</script>
+
+<NumberTicker
+	value={100.50}
+	decimalPlaces={2}
+	startValue={70}
+  prefix="$"
+  suffix="USD"
+	class="text-8xl font-medium tracking-tighter whitespace-pre-wrap text-black dark:text-white"
+/>


### PR DESCRIPTION
This allows us to include a prefix and suffix to the NumberTicker Component.