### PR TITLE
docs: update CREATE_COMPONENT_GUIDE.md to cover Spell UI workflow

### DIFF
--- a/CREATE_COMPONENT_GUIDE.md
+++ b/CREATE_COMPONENT_GUIDE.md
@@ -1,39 +1,38 @@
 # Create Component Guide
 
-This guide walks you through the complete process of creating and publishing a new component. The project has two component libraries: **Magic UI** (the original) and **Spell UI** (ported from [spell.sh](https://spell.sh)). Each has its own folder structure, registry, and conventions.
+This guide walks you through the complete process of creating and publishing a new component. There are two libraries: **Magic UI** (components from [magicui.design](https://magicui.design)) and **Spell UI** (components from [spell.sh](https://spell.sh)). The steps are the same — just swap the paths shown as `magic / spell` below.
 
 ---
 
-## Which library should my component go in?
+## Quick Overview
 
-| Library | Source inspiration | Component folder | Route folder | Registry file |
-|---------|-------------------|-----------------|--------------|---------------|
-| **Magic UI** | [magicui.design](https://magicui.design) | `src/lib/components/magic/` | `src/routes/magic/docs/components/` | `registry.json` |
-| **Spell UI** | [spell.sh](https://spell.sh) | `src/lib/components/spell/` | `src/routes/spell/` | `spell-registry.json` |
+| | Magic UI | Spell UI |
+|---|---|---|
+| Component folder | `src/lib/components/magic/` | `src/lib/components/spell/` |
+| Route folder | `src/routes/magic/docs/components/` | `src/routes/spell/` |
+| Registry file | `registry.json` | `spell-registry.json` |
+| Build command | `pnpm registry:build` → `static/r/` | `pnpm spell:build` → `static/s/` |
+| Sidebar registration | `src/lib/components/docs/registry/magic-ui.ts` | `src/lib/components/docs/registry/spell_ui.ts` |
 
-If you are porting a component from spell.sh, follow the **Spell UI** path below. Otherwise, use **Magic UI**.
-
----
-
-## Magic UI — Quick Overview
-
-1. Create main component in `src/lib/components/magic/`
-2. Create route in `src/routes/magic/docs/components/`
-3. Add component to `registry.json`
-4. Build registry: `pnpm registry:build`
+1. Create main component in `src/lib/components/[magic|spell]/`
+2. Create route in `src/routes/[magic/docs/components|spell]/`
+3. Add component to `[registry.json|spell-registry.json]`
+4. Build registry: `pnpm [registry:build|spell:build]`
 5. Test component installation
 6. Make a PR
 
+**Spell UI only:** also add your component to `spell_ui.ts` and import its preview in `showcase-data.ts`.
+
 ---
 
-## Magic UI — Step 1: Create Main Component
+## Step 1: Create Main Component
 
-Create your component folder inside `src/lib/components/magic/`.
+Create your component folder inside `src/lib/components/[magic|spell]/`.
 
 ### Folder Structure
 
 ```
-src/lib/components/magic/
+src/lib/components/[magic|spell]/
 └── your-component/
     ├── your-component.svelte    # Main component
     ├── index.ts                 # Exports
@@ -41,14 +40,14 @@ src/lib/components/magic/
     └── use-*.svelte.ts          # (optional) Composable
 ```
 
-## Magic UI — Step 2: Create Route
+## Step 2: Create Route
 
-Create a new folder inside `src/routes/magic/docs/components/` with your component name.
+Create a new folder inside `src/routes/[magic/docs/components|spell]/` with your component name.
 
 ### Required Files Structure
 
 ```
-src/routes/magic/docs/components/your-component/
+src/routes/[magic/docs/components|spell]/your-component/
 ├── +page.svelte          # Page component
 ├── docs.md               # Documentation for AI/LLMs
 ├── data.ts               # Component data (types, code, SEO, examples)
@@ -99,9 +98,9 @@ folderStructure: `src/
 	│           └── index.ts
   ```
 
-## Magic UI — Step 3: Add Component to `registry.json`
+## Step 3: Add Component to `[registry.json|spell-registry.json]`
 
-Add your component entry to the `items` array in `registry.json`:
+Add your component entry to the `items` array in `registry.json` (Magic) or `spell-registry.json` (Spell):
 
 ```json
 {
@@ -149,19 +148,20 @@ For components with custom CSS animations:
 
 ---
 
-## Magic UI — Step 4: Build Registry
+## Step 4: Build Registry
 
 Run the registry build command:
 
 ```bash
-pnpm registry:build
+pnpm registry:build   # Magic UI → static/r/
+pnpm spell:build      # Spell UI → static/s/
 ```
 
-This generates JSON files in `static/r/` for each component, enabling CLI installation.
+This generates JSON files for each component, enabling CLI installation.
 
 ---
 
-## Magic UI — Step 5: Test Component Installation
+## Step 5: Test Component Installation
 
 Test the component can be installed correctly:
 
@@ -179,7 +179,7 @@ npx shadcn-svelte@latest add "http://localhost:5173/r/your-component.json"
 
 ---
 
-## Magic UI — Step 6: Make a PR
+## Step 6: Make a PR
 
 1. **Create a branch**:
 
@@ -201,273 +201,27 @@ npx shadcn-svelte@latest add "http://localhost:5173/r/your-component.json"
    ```
 
 4. **PR Checklist**:
-   - [ ] Component created in `src/lib/components/magic/`
-   - [ ] Route created in `src/routes/magic/docs/components/`
+   - [ ] Component created in `src/lib/components/[magic|spell]/`
+   - [ ] Route created in `src/routes/[magic/docs/components|spell]/`
    - [ ] `+page.svelte` with proper SEO
    - [ ] `llms.txt/+server.ts` serving `docs.md`
    - [ ] `docs.md` with AI-readable documentation
    - [ ] `examples/` with `preview.svelte` and any variants
    - [ ] `data.ts` with proper types, code, SEO, examples
-   - [ ] Component added to `registry.json`
-   - [ ] Registry built successfully (`pnpm registry:build`)
+   - [ ] Component added to `[registry.json|spell-registry.json]`
+   - [ ] Registry built successfully (`pnpm [registry:build|spell:build]`)
    - [ ] Component tested via installation
-
----
-
----
-
-# Spell UI Components
-
-Spell UI components are ported from [spell.sh](https://spell.sh). They follow a similar pattern to Magic UI but use a different folder structure and registry.
-
-## Spell UI — Quick Overview
-
-1. Create main component in `src/lib/components/spell/`
-2. Create route in `src/routes/spell/`
-3. Add component to `spell-registry.json`
-4. Build registry: `pnpm spell:build` (generates `static/s/`)
-5. Register component in `src/lib/components/docs/registry/spell_ui.ts`
-6. Add preview to `src/lib/components/layout/spell/showcase-data.ts`
-7. Make a PR
-
----
-
-## Spell UI — Step 1: Create Main Component
-
-Create your component folder inside `src/lib/components/spell/`.
-
-```
-src/lib/components/spell/
-└── your-component/
-    ├── your-component.svelte    # Main component
-    └── index.ts                 # Exports (re-export the component)
-```
-
-### `index.ts` pattern
-
-```typescript
-export { default as YourComponent } from "./your-component.svelte";
-```
-
----
-
-## Spell UI — Step 2: Create Route
-
-Create a folder inside `src/routes/spell/` (not inside `docs/components/` — Spell routes live at the top level of `/spell/`).
-
-```
-src/routes/spell/your-component/
-├── +page.svelte          # Page — copy from another Spell component
-├── docs.md               # AI-readable documentation
-├── data.ts               # Component data (meta, SEO, install, examples)
-├── examples/
-│   ├── preview.svelte    # Main preview
-│   └── *.svelte          # Variant examples
-└── llms.txt/
-    └── +server.ts        # Serves docs.md as plain text (copy verbatim)
-```
-
-### `+page.svelte` pattern
-
-```svelte
-<script lang="ts">
-  import ComponentDocPage from "$lib/components/docs/base/ComponentDocPage.svelte";
-  import { data } from "./data";
-</script>
-
-<ComponentDocPage
-  id={data.id}
-  title={data.title}
-  description={data.description}
-  seo={data.seo}
-  preview={data.preview}
-  previewCode={data.previewCode}
-  installCodeBlocks={data.installBlock?.installCode}
-  installPackages={data.installBlock?.packages}
-  installFolderStructure={data.installBlock?.folderStructure}
-  examples={data.examples}
-  propsTables={data.props}
-  descriptionClass="max-w-xl"
-/>
-```
-
-### `data.ts` pattern
-
-```typescript
-import YourComponentRaw from "$lib/components/spell/your-component/your-component.svelte?raw";
-import IndexTsRaw from "$lib/components/spell/your-component/index.ts?raw";
-import type { ComponentDoc, ComponentMeta, InstallComponentDocs } from "$lib/types/structure";
-import type { SEO } from "$lib/types/seo";
-import Preview from "./examples/preview.svelte";
-import PreviewCodeRaw from "./examples/preview.svelte?raw";
-
-export const meta: ComponentMeta = {
-  id: "your-component",
-  title: "Your Component",
-  description: "One-sentence description shown on the docs page.",
-  category: "Components", // One of the SpellCategory values
-};
-
-const seo: SEO = {
-  title: "Your Component",
-  description: "Longer SEO description.",
-  keywords: ["Svelte", "Your Component", "Spell", "Svelte Animations"],
-};
-
-const installBlock: InstallComponentDocs = {
-  installCode: [
-    {
-      filename: "your-component.svelte",
-      filecode: YourComponentRaw,
-      lang: "svelte",
-      isExpand: true,
-    },
-    {
-      filename: "index.ts",
-      filecode: IndexTsRaw,
-      lang: "typescript",
-    },
-  ],
-  folderStructure: `src/
-lib/
-  components/
-    spell/
-      your-component/
-        your-component.svelte
-        index.ts`,
-};
-
-export const data: ComponentDoc = {
-  ...meta,
-  seo,
-  preview: Preview,
-  previewCode: {
-    filename: "preview.svelte",
-    filecode: PreviewCodeRaw,
-    lang: "svelte",
-    hideLines: true,
-  },
-  installBlock,
-  examples: [
-    // additional examples go here
-  ],
-};
-```
-
-### `llms.txt/+server.ts` (copy verbatim)
-
-```typescript
-import type { RequestHandler } from "./$types";
-import docs from "../docs.md?raw";
-
-export const GET: RequestHandler = async () => {
-  return new Response(docs, {
-    headers: {
-      "Content-Type": "text/plain; charset=utf-8",
-      "Cache-Control": "public, max-age=3600",
-    },
-  });
-};
-```
-
----
-
-## Spell UI — Step 3: Add to `spell-registry.json`
-
-Add an entry to the `items` array in `spell-registry.json`:
-
-```json
-{
-  "name": "your-component",
-  "type": "registry:block",
-  "title": "Your Component",
-  "description": "Brief description.",
-  "files": [
-    {
-      "path": "./src/lib/components/spell/your-component/your-component.svelte",
-      "type": "registry:component",
-      "target": "spell/your-component/your-component.svelte"
-    },
-    {
-      "path": "./src/lib/components/spell/your-component/index.ts",
-      "type": "registry:file",
-      "target": "spell/your-component/index.ts"
-    }
-  ],
-  "registryDependencies": []
-}
-```
-
----
-
-## Spell UI — Step 4: Build Registry
-
-```bash
-pnpm spell:build
-```
-
-This generates `static/s/your-component.json` and updates `static/s/index.json`.
-
----
-
-## Spell UI — Step 5: Register in `spell_ui.ts`
-
-Add your component to `src/lib/components/docs/registry/spell_ui.ts`:
-
-```typescript
-{
-  id: "your-component",
-  name: "Your Component",
-  href: "/spell/your-component",
-  category: "Components",  // must be a valid SpellCategory
-  desc: "One-sentence description for the sidebar.",
-  badge: "New",            // optional: "New" | "Beta" | "Updated"
-},
-```
-
-Place it in the correct category section. The category must be one of:
-`"Overview"` | `"Components"` | `"Text Animations"` | `"Buttons"` | `"Inputs"` | `"Feedback"` | `"Backgrounds"` | `"Interactive"`
-
----
-
-## Spell UI — Step 6: Add to Overview Showcase
-
-Import your preview in `src/lib/components/layout/spell/showcase-data.ts`:
-
-```typescript
-import YourComponentPreview from "../../../../routes/spell/your-component/examples/preview.svelte";
-
-// In previewById:
-"your-component": YourComponentPreview,
-```
-
-The overview page will automatically include it if the component is in `spellUIComponents`.
-
----
-
-## Spell UI — Step 7: Make a PR
-
-**PR Checklist**:
-- [ ] Component created in `src/lib/components/spell/`
-- [ ] Route created in `src/routes/spell/your-component/`
-- [ ] `+page.svelte` using `ComponentDocPage`
-- [ ] `docs.md` with AI-readable documentation
-- [ ] `llms.txt/+server.ts` serving `docs.md`
-- [ ] `data.ts` with `meta`, `seo`, `installBlock`, and `examples`
-- [ ] `examples/preview.svelte` plus at least one variant
-- [ ] Entry added to `spell-registry.json`
-- [ ] Registry built (`pnpm spell:build`) — `static/s/your-component.json` exists
-- [ ] Entry added to `spell_ui.ts` with correct category
-- [ ] Preview imported in `showcase-data.ts`
+   - [ ] **(Spell only)** Entry added to `spell_ui.ts` with correct category
+   - [ ] **(Spell only)** Preview imported in `showcase-data.ts`
 
 ---
 
 ## Best Practices
 
 - **Naming**: Use kebab-case for folder/file names and component IDs
-- **Props**: Document all props with types and defaults in `docs.md`
-- **Examples**: Create at least a `preview.svelte` and one meaningful variant
-- **Dependencies**: Only include necessary npm packages; document them in `installBlock.packages`
-- **CSS**: Use Tailwind classes when possible; avoid component-scoped `<style>` blocks for keyframes (put them in `src/routes/layout.css` instead so Tailwind can process them)
-- **svelte-check**: Run `pnpm check` before submitting — fix all type errors and a11y warnings
-- **Svelte 5**: Use `$state`, `$derived`, `$props()` runes; avoid legacy `export let` style props
+- **Props**: Document all props with types and defaults
+- **Examples**: Create at least one preview and one variant example
+- **Dependencies**: Only include necessary npm packages
+- **CSS**: Use Tailwind classes when possible; use `cssVars`/`css` for animations. Put custom `@keyframes` in `src/routes/layout.css` rather than component `<style>` blocks so Tailwind can process them
+- **Svelte 5**: Use `$state`, `$derived`, `$props()` runes — avoid legacy `export let` props
+- **Testing**: Always test installation in a fresh project before PR; run `pnpm check` to catch type/a11y warnings

--- a/CREATE_COMPONENT_GUIDE.md
+++ b/CREATE_COMPONENT_GUIDE.md
@@ -1,10 +1,21 @@
 # Create Component Guide
 
-This guide walks you through the complete process of creating and publishing a new component in the svelte animationss.
+This guide walks you through the complete process of creating and publishing a new component. The project has two component libraries: **Magic UI** (the original) and **Spell UI** (ported from [spell.sh](https://spell.sh)). Each has its own folder structure, registry, and conventions.
 
 ---
 
-## Quick Overview
+## Which library should my component go in?
+
+| Library | Source inspiration | Component folder | Route folder | Registry file |
+|---------|-------------------|-----------------|--------------|---------------|
+| **Magic UI** | [magicui.design](https://magicui.design) | `src/lib/components/magic/` | `src/routes/magic/docs/components/` | `registry.json` |
+| **Spell UI** | [spell.sh](https://spell.sh) | `src/lib/components/spell/` | `src/routes/spell/` | `spell-registry.json` |
+
+If you are porting a component from spell.sh, follow the **Spell UI** path below. Otherwise, use **Magic UI**.
+
+---
+
+## Magic UI — Quick Overview
 
 1. Create main component in `src/lib/components/magic/`
 2. Create route in `src/routes/magic/docs/components/`
@@ -15,7 +26,7 @@ This guide walks you through the complete process of creating and publishing a n
 
 ---
 
-## Step 1: Create Main Component
+## Magic UI — Step 1: Create Main Component
 
 Create your component folder inside `src/lib/components/magic/`.
 
@@ -30,7 +41,7 @@ src/lib/components/magic/
     └── use-*.svelte.ts          # (optional) Composable
 ```
 
-## Step 2: Create Route
+## Magic UI — Step 2: Create Route
 
 Create a new folder inside `src/routes/magic/docs/components/` with your component name.
 
@@ -88,7 +99,7 @@ folderStructure: `src/
 	│           └── index.ts
   ```
 
-## Step 3: Add Component to `registry.json`
+## Magic UI — Step 3: Add Component to `registry.json`
 
 Add your component entry to the `items` array in `registry.json`:
 
@@ -138,7 +149,7 @@ For components with custom CSS animations:
 
 ---
 
-## Step 4: Build Registry
+## Magic UI — Step 4: Build Registry
 
 Run the registry build command:
 
@@ -150,7 +161,7 @@ This generates JSON files in `static/r/` for each component, enabling CLI instal
 
 ---
 
-## Step 5: Test Component Installation
+## Magic UI — Step 5: Test Component Installation
 
 Test the component can be installed correctly:
 
@@ -168,7 +179,7 @@ npx shadcn-svelte@latest add "http://localhost:5173/r/your-component.json"
 
 ---
 
-## Step 6: Make a PR
+## Magic UI — Step 6: Make a PR
 
 1. **Create a branch**:
 
@@ -203,11 +214,260 @@ npx shadcn-svelte@latest add "http://localhost:5173/r/your-component.json"
 
 ---
 
+---
+
+# Spell UI Components
+
+Spell UI components are ported from [spell.sh](https://spell.sh). They follow a similar pattern to Magic UI but use a different folder structure and registry.
+
+## Spell UI — Quick Overview
+
+1. Create main component in `src/lib/components/spell/`
+2. Create route in `src/routes/spell/`
+3. Add component to `spell-registry.json`
+4. Build registry: `pnpm spell:build` (generates `static/s/`)
+5. Register component in `src/lib/components/docs/registry/spell_ui.ts`
+6. Add preview to `src/lib/components/layout/spell/showcase-data.ts`
+7. Make a PR
+
+---
+
+## Spell UI — Step 1: Create Main Component
+
+Create your component folder inside `src/lib/components/spell/`.
+
+```
+src/lib/components/spell/
+└── your-component/
+    ├── your-component.svelte    # Main component
+    └── index.ts                 # Exports (re-export the component)
+```
+
+### `index.ts` pattern
+
+```typescript
+export { default as YourComponent } from "./your-component.svelte";
+```
+
+---
+
+## Spell UI — Step 2: Create Route
+
+Create a folder inside `src/routes/spell/` (not inside `docs/components/` — Spell routes live at the top level of `/spell/`).
+
+```
+src/routes/spell/your-component/
+├── +page.svelte          # Page — copy from another Spell component
+├── docs.md               # AI-readable documentation
+├── data.ts               # Component data (meta, SEO, install, examples)
+├── examples/
+│   ├── preview.svelte    # Main preview
+│   └── *.svelte          # Variant examples
+└── llms.txt/
+    └── +server.ts        # Serves docs.md as plain text (copy verbatim)
+```
+
+### `+page.svelte` pattern
+
+```svelte
+<script lang="ts">
+  import ComponentDocPage from "$lib/components/docs/base/ComponentDocPage.svelte";
+  import { data } from "./data";
+</script>
+
+<ComponentDocPage
+  id={data.id}
+  title={data.title}
+  description={data.description}
+  seo={data.seo}
+  preview={data.preview}
+  previewCode={data.previewCode}
+  installCodeBlocks={data.installBlock?.installCode}
+  installPackages={data.installBlock?.packages}
+  installFolderStructure={data.installBlock?.folderStructure}
+  examples={data.examples}
+  propsTables={data.props}
+  descriptionClass="max-w-xl"
+/>
+```
+
+### `data.ts` pattern
+
+```typescript
+import YourComponentRaw from "$lib/components/spell/your-component/your-component.svelte?raw";
+import IndexTsRaw from "$lib/components/spell/your-component/index.ts?raw";
+import type { ComponentDoc, ComponentMeta, InstallComponentDocs } from "$lib/types/structure";
+import type { SEO } from "$lib/types/seo";
+import Preview from "./examples/preview.svelte";
+import PreviewCodeRaw from "./examples/preview.svelte?raw";
+
+export const meta: ComponentMeta = {
+  id: "your-component",
+  title: "Your Component",
+  description: "One-sentence description shown on the docs page.",
+  category: "Components", // One of the SpellCategory values
+};
+
+const seo: SEO = {
+  title: "Your Component",
+  description: "Longer SEO description.",
+  keywords: ["Svelte", "Your Component", "Spell", "Svelte Animations"],
+};
+
+const installBlock: InstallComponentDocs = {
+  installCode: [
+    {
+      filename: "your-component.svelte",
+      filecode: YourComponentRaw,
+      lang: "svelte",
+      isExpand: true,
+    },
+    {
+      filename: "index.ts",
+      filecode: IndexTsRaw,
+      lang: "typescript",
+    },
+  ],
+  folderStructure: `src/
+lib/
+  components/
+    spell/
+      your-component/
+        your-component.svelte
+        index.ts`,
+};
+
+export const data: ComponentDoc = {
+  ...meta,
+  seo,
+  preview: Preview,
+  previewCode: {
+    filename: "preview.svelte",
+    filecode: PreviewCodeRaw,
+    lang: "svelte",
+    hideLines: true,
+  },
+  installBlock,
+  examples: [
+    // additional examples go here
+  ],
+};
+```
+
+### `llms.txt/+server.ts` (copy verbatim)
+
+```typescript
+import type { RequestHandler } from "./$types";
+import docs from "../docs.md?raw";
+
+export const GET: RequestHandler = async () => {
+  return new Response(docs, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+};
+```
+
+---
+
+## Spell UI — Step 3: Add to `spell-registry.json`
+
+Add an entry to the `items` array in `spell-registry.json`:
+
+```json
+{
+  "name": "your-component",
+  "type": "registry:block",
+  "title": "Your Component",
+  "description": "Brief description.",
+  "files": [
+    {
+      "path": "./src/lib/components/spell/your-component/your-component.svelte",
+      "type": "registry:component",
+      "target": "spell/your-component/your-component.svelte"
+    },
+    {
+      "path": "./src/lib/components/spell/your-component/index.ts",
+      "type": "registry:file",
+      "target": "spell/your-component/index.ts"
+    }
+  ],
+  "registryDependencies": []
+}
+```
+
+---
+
+## Spell UI — Step 4: Build Registry
+
+```bash
+pnpm spell:build
+```
+
+This generates `static/s/your-component.json` and updates `static/s/index.json`.
+
+---
+
+## Spell UI — Step 5: Register in `spell_ui.ts`
+
+Add your component to `src/lib/components/docs/registry/spell_ui.ts`:
+
+```typescript
+{
+  id: "your-component",
+  name: "Your Component",
+  href: "/spell/your-component",
+  category: "Components",  // must be a valid SpellCategory
+  desc: "One-sentence description for the sidebar.",
+  badge: "New",            // optional: "New" | "Beta" | "Updated"
+},
+```
+
+Place it in the correct category section. The category must be one of:
+`"Overview"` | `"Components"` | `"Text Animations"` | `"Buttons"` | `"Inputs"` | `"Feedback"` | `"Backgrounds"` | `"Interactive"`
+
+---
+
+## Spell UI — Step 6: Add to Overview Showcase
+
+Import your preview in `src/lib/components/layout/spell/showcase-data.ts`:
+
+```typescript
+import YourComponentPreview from "../../../../routes/spell/your-component/examples/preview.svelte";
+
+// In previewById:
+"your-component": YourComponentPreview,
+```
+
+The overview page will automatically include it if the component is in `spellUIComponents`.
+
+---
+
+## Spell UI — Step 7: Make a PR
+
+**PR Checklist**:
+- [ ] Component created in `src/lib/components/spell/`
+- [ ] Route created in `src/routes/spell/your-component/`
+- [ ] `+page.svelte` using `ComponentDocPage`
+- [ ] `docs.md` with AI-readable documentation
+- [ ] `llms.txt/+server.ts` serving `docs.md`
+- [ ] `data.ts` with `meta`, `seo`, `installBlock`, and `examples`
+- [ ] `examples/preview.svelte` plus at least one variant
+- [ ] Entry added to `spell-registry.json`
+- [ ] Registry built (`pnpm spell:build`) — `static/s/your-component.json` exists
+- [ ] Entry added to `spell_ui.ts` with correct category
+- [ ] Preview imported in `showcase-data.ts`
+
+---
+
 ## Best Practices
 
 - **Naming**: Use kebab-case for folder/file names and component IDs
-- **Props**: Document all props with types and defaults
-- **Examples**: Create at least one preview and one variant example
-- **Dependencies**: Only include necessary npm packages
-- **CSS**: Use Tailwind classes when possible; use `cssVars`/`css` for animations
-- **Testing**: Always test installation in a fresh project before PR
+- **Props**: Document all props with types and defaults in `docs.md`
+- **Examples**: Create at least a `preview.svelte` and one meaningful variant
+- **Dependencies**: Only include necessary npm packages; document them in `installBlock.packages`
+- **CSS**: Use Tailwind classes when possible; avoid component-scoped `<style>` blocks for keyframes (put them in `src/routes/layout.css` instead so Tailwind can process them)
+- **svelte-check**: Run `pnpm check` before submitting — fix all type errors and a11y warnings
+- **Svelte 5**: Use `$state`, `$derived`, `$props()` runes; avoid legacy `export let` style props


### PR DESCRIPTION
Extends `CREATE_COMPONENT_GUIDE.md` to cover Spell UI alongside Magic UI, without duplicating the full instructions.

Changes:
- Intro paragraph noting the two libraries
- Comparison table (folder, route, registry, build command, sidebar file)
- Replace Magic-specific paths with `[magic|spell]` placeholders throughout
- Two Spell-only checklist items: `spell_ui.ts` registration and `showcase-data.ts` preview import
- Best Practices: add keyframes-in-layout.css note and Svelte 5 runes reminder

🤖 Generated with [Claude Code](https://claude.com/claude-code)